### PR TITLE
Optimize ray_optical_depth

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -22,7 +22,7 @@ def density_ozone(height):
         return 0
     elif height >= 10000 and height < 25000:
         return 1 / 15000 * height - 2 / 3
-    elif height >= 25000 and height < 40000:
+    else: # height >= 25000 and height < 40000:
         return -(1 / 15000 * height - 8 / 3)
 
 def phase_rayleigh(mu):

--- a/light.py
+++ b/light.py
@@ -19,20 +19,22 @@ def ray_optical_depth(ray_origin, ray_dir):
     # step along the ray in segments and accumulate the optical depth along each segment
     segment_length = ray_length / steps_light
     segment = segment_length * ray_dir
+    
     optical_depth = np.zeros(3)
     # the density of each segment is evaluated at its middle
     P = ray_origin + 0.5 * segment
+    segment_height = sqrt(np.dot(segment, segment))
+    # height above sea level
+    P_height = sqrt(np.dot(P, P)) - earth_radius
     
     for _ in range(steps_light):
-        # height above sea level
-        height = sqrt(np.dot(P, P)) - earth_radius
         # accumulate optical depth of this segment
-        density = np.array([fun.density_rayleigh(height), fun.density_mie(height), fun.density_ozone(height)])
-        optical_depth += segment_length * density
+        density = np.array([fun.density_rayleigh(P_height), fun.density_mie(P_height), fun.density_ozone(P_height)])
+        optical_depth += density
         # advance along ray
-        P += segment
+        P_height += segment_height
 
-    return optical_depth
+    return optical_depth * segment_length
 
 
 def single_scattering(ray_dir):


### PR DESCRIPTION
It appears this is wheere the bulk of time is spent.  In my single threaded test it brought the time spent there from 44->24 sec.

This could be further optimized by vectorizing the for loop with numpy.  Also This is not ready for merge because I haven't tested correctness.  But wanted to give you an idea.  