### PR TITLE
Vectorize for loop in light.py

### DIFF
--- a/light.py
+++ b/light.py
@@ -24,17 +24,11 @@ def ray_optical_depth(ray_origin, ray_dir):
     optical_depth = np.zeros(3)
     # the density of each segment is evaluated at its middle
     P = ray_origin + 0.5 * segment
+    # height above sea level
+    height = sqrt(np.dot(P, P)) - earth_radius
 
-    for _ in range(steps_light):
-        # height above sea level
-        height = sqrt(np.dot(P, P)) - earth_radius
-        # accumulate optical depth of this segment
-        density = np.array([fun.density_rayleigh(height), fun.density_mie(height), fun.density_ozone(height)])
-        optical_depth += density
-        # advance along ray
-        P += segment
-
-    return optical_depth * segment_length
+    optical_depths = np.array([[fun.density_rayleigh(height + n * segment_length), fun.density_mie(height + n * segment_length), fun.density_ozone(height + n * segment_length)] for n in range(steps_light)])
+    return optical_depths.sum(axis=0) * segment_length
 
 
 def single_scattering(ray_dir):


### PR DESCRIPTION
In my finding this was the main time sink.  In a single threaded run it took 34 sec just in this loop.  I brought that down to < 20.  Please check for numerical correctness though.  

Previous code was 
```
for _ in range(steps_light):
        # height above sea level
        height = sqrt(np.dot(P, P)) - earth_radius
        # accumulate optical depth of this segment
        density = np.array([fun.density_rayleigh(height), fun.density_mie(height), fun.density_ozone(height)])
        optical_depth += density
        # advance along ray
        P += segment
```

We can note a few things here.  
1.  Height is a length of P - earth radius.  We add segment to P every iteration.  Therefore we can just add segment_length each iteration.
2.  Rather than making a 3 item array each iteration and adding it, let numpy do the work here.  Make a 3 x steps array, and sum columns.

